### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=https://github.com/Jeard
 sentence=ESP32 Aes base64 encryption 
 paragraph=An Arduino ESP32 library to encrypt large char arrays using AES encryption and returns a Base_64 encoded string
 category=Other
-url=jlanka.com
+url=https://jlanka.com
 architectures=esp32


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.