### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,9 +11,9 @@ __AesB64	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-encry_arr2arr    	    KEYWORD2
-encry_arr2str    	    KEYWORD2
-add_padding             KEYWORD2
+encry_arr2arr	KEYWORD2
+encry_arr2str	KEYWORD2
+add_padding	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords